### PR TITLE
Update checkTargetDir to support Node 8.1

### DIFF
--- a/lib/cliHelper.js
+++ b/lib/cliHelper.js
@@ -72,6 +72,9 @@ function filterFiles(fileList, filter) {
 }
 
 function checkTargetDir(targetDir) {
+    if (fs.existsSync) {
+        path.existsSync = fs.existsSync;
+    }
     if (!path.existsSync(targetDir)) {
         fs.mkdirSync(targetDir, "0755");
     }


### PR DESCRIPTION
In Node 8.1, path.existsSync was moved to fs.existsSync
